### PR TITLE
Help text for plots and width of plots

### DIFF
--- a/components/plots.tsx
+++ b/components/plots.tsx
@@ -1,26 +1,33 @@
+import { Typography } from "@material-ui/core"
 import { useExperiment } from "../context/experiment-context"
+import useStyles from "../styles/plots.style"
 import { TitleCard } from "./title-card"
 
 export const Plots = () => {
   const { state: { experiment } } = useExperiment()
+  const classes = useStyles()
 
   return (
     <>
       <TitleCard title="Plots">
         {experiment.results.plots.length > 0 ?
           <ul>
-              <h3>Convergence plot</h3>
-              <p>The convegence plot displays the score of the best observation as a function of the number of calls.</p>
-              {experiment.results.plots.filter(plot => plot.id == "convergence").map(plot => <li key={plot.id}><img src={`data:image/png;base64, ${plot.plot}`} width="800" alt={plot.id}></img></li>)}
+              <Typography variant="subtitle1"><b>Convergence plot</b></Typography>
+              <Typography variant="body2" paragraph={true}>
+                The convegence plot displays the score of the best observation as a function of the number of calls.
+              </Typography>
+              {experiment.results.plots.filter(plot => plot.id === "convergence").map(plot => <li className={classes.listItem} key={plot.id}><img src={`data:image/png;base64, ${plot.plot}`} width="800" alt={plot.id}></img></li>)}
               
-              <h3>Objective plot</h3>
-              <p>The objective plot displays the model approximating the objective function.<br/>
-              In the diagonal the dependence of the model on each input variable is shown.
-              For each input variable the other input variables are set by the best observation.<br/>
-              In the lower triangle the pairwise dependencies of the model on each pair of input variables.
-              For each pair the other input variables are set by the best observation.<br/>
-              The best observation is marked with a red dot while the remaining observations are marked with orange dots.</p>
-               {experiment.results.plots.filter(plot => plot.id == "objective").map(plot => <li key={plot.id}><img src={`data:image/png;base64, ${plot.plot}`} width="800" alt={plot.id}></img></li>)}
+              <Typography variant="subtitle1"><b>Objective plot</b></Typography>
+              <Typography variant="body2" paragraph={true}>
+                The objective plot displays the model approximating the objective function.<br/>
+                In the diagonal the dependence of the model on each input variable is shown.
+                For each input variable the other input variables are set by the best observation.<br/>
+                In the lower triangle the pairwise dependencies of the model on each pair of input variables.
+                For each pair the other input variables are set by the best observation.<br/>
+                The best observation is marked with a red dot while the remaining observations are marked with orange dots.
+              </Typography>
+              {experiment.results.plots.filter(plot => plot.id === "objective").map(plot => <li className={classes.listItem} key={plot.id}><img src={`data:image/png;base64, ${plot.plot}`} width="800" alt={plot.id}></img></li>)}
           </ul>
           :
           "Plots will appear here"

--- a/components/plots.tsx
+++ b/components/plots.tsx
@@ -9,7 +9,18 @@ export const Plots = () => {
       <TitleCard title="Plots">
         {experiment.results.plots.length > 0 ?
           <ul>
-              {experiment.results.plots && experiment.results.plots.map(plot => <li key={plot.id}><img src={`data:image/png;base64, ${plot.plot}`} alt={plot.id}></img></li>)}
+              <h3>Convergence plot</h3>
+              <p>The convegence plot displays the score of the best observation as a function of the number of calls.</p>
+              {experiment.results.plots.filter(plot => plot.id == "convergence").map(plot => <li key={plot.id}><img src={`data:image/png;base64, ${plot.plot}`} width="800" alt={plot.id}></img></li>)}
+              
+              <h3>Objective plot</h3>
+              <p>The objective plot displays the model approximating the objective function.<br/>
+              In the diagonal the dependence of the model on each input variable is shown.
+              For each input variable the other input variables are set by the best observation.<br/>
+              In the lower triangle the pairwise dependencies of the model on each pair of input variables.
+              For each pair the other input variables are set by the best observation.<br/>
+              The best observation is marked with a red dot while the remaining observations are marked with orange dots.</p>
+               {experiment.results.plots.filter(plot => plot.id == "objective").map(plot => <li key={plot.id}><img src={`data:image/png;base64, ${plot.plot}`} width="800" alt={plot.id}></img></li>)}
           </ul>
           :
           "Plots will appear here"

--- a/components/plots.tsx
+++ b/components/plots.tsx
@@ -16,7 +16,7 @@ export const Plots = () => {
               <Typography variant="body2" paragraph={true}>
                 The convegence plot displays the score of the best observation as a function of the number of calls.
               </Typography>
-              {experiment.results.plots.filter(plot => plot.id === "convergence").map(plot => <li className={classes.listItem} key={plot.id}><img className={classes.Image} src={`data:image/png;base64, ${plot.plot}`} alt={plot.id}></img></li>)}
+              {experiment.results.plots.filter(plot => plot.id === "convergence").map(plot => <li className={classes.listItem} key={plot.id}><img className={classes.convergenceImage} src={`data:image/png;base64, ${plot.plot}`} alt={plot.id}></img></li>)}
               
               <Typography variant="subtitle1"><b>Objective plot</b></Typography>
               <Typography variant="body2" paragraph={true}>
@@ -27,7 +27,7 @@ export const Plots = () => {
                 For each pair the other input variables are set by the best observation.<br/>
                 The best observation is marked with a red dot while the remaining observations are marked with orange dots.
               </Typography>
-              {experiment.results.plots.filter(plot => plot.id === "objective").map(plot => <li className={classes.listItem} key={plot.id}><img className={classes.Image} src={`data:image/png;base64, ${plot.plot}`} alt={plot.id}></img></li>)}
+              {experiment.results.plots.filter(plot => plot.id === "objective").map(plot => <li className={classes.listItem} key={plot.id}><img className={classes.objectiveImage} src={`data:image/png;base64, ${plot.plot}`} alt={plot.id}></img></li>)}
           </ul>
           :
           "Plots will appear here"

--- a/components/plots.tsx
+++ b/components/plots.tsx
@@ -16,7 +16,7 @@ export const Plots = () => {
               <Typography variant="body2" paragraph={true}>
                 The convegence plot displays the score of the best observation as a function of the number of calls.
               </Typography>
-              {experiment.results.plots.filter(plot => plot.id === "convergence").map(plot => <li className={classes.listItem} key={plot.id}><img src={`data:image/png;base64, ${plot.plot}`} width="800" alt={plot.id}></img></li>)}
+              {experiment.results.plots.filter(plot => plot.id === "convergence").map(plot => <li className={classes.listItem} key={plot.id}><img className={classes.Image} src={`data:image/png;base64, ${plot.plot}`} alt={plot.id}></img></li>)}
               
               <Typography variant="subtitle1"><b>Objective plot</b></Typography>
               <Typography variant="body2" paragraph={true}>
@@ -27,7 +27,7 @@ export const Plots = () => {
                 For each pair the other input variables are set by the best observation.<br/>
                 The best observation is marked with a red dot while the remaining observations are marked with orange dots.
               </Typography>
-              {experiment.results.plots.filter(plot => plot.id === "objective").map(plot => <li className={classes.listItem} key={plot.id}><img src={`data:image/png;base64, ${plot.plot}`} width="800" alt={plot.id}></img></li>)}
+              {experiment.results.plots.filter(plot => plot.id === "objective").map(plot => <li className={classes.listItem} key={plot.id}><img className={classes.Image} src={`data:image/png;base64, ${plot.plot}`} alt={plot.id}></img></li>)}
           </ul>
           :
           "Plots will appear here"

--- a/styles/plots.style.tsx
+++ b/styles/plots.style.tsx
@@ -1,0 +1,9 @@
+import { makeStyles } from "@material-ui/core";
+
+export const useStyles = makeStyles(theme => ({
+  listItem: {
+    listStyle: 'none',
+  },
+}));
+
+export default useStyles

--- a/styles/plots.style.tsx
+++ b/styles/plots.style.tsx
@@ -4,9 +4,12 @@ export const useStyles = makeStyles(theme => ({
   listItem: {
     listStyle: 'none',
   },
-  Image: {
+  convergenceImage: {
     width: '100%',
-    maxWidth: 800
+    maxWidth: 800,
+  },
+  objectiveImage: {
+    maxWidth: '100%',
   },
 }));
 

--- a/styles/plots.style.tsx
+++ b/styles/plots.style.tsx
@@ -5,7 +5,8 @@ export const useStyles = makeStyles(theme => ({
     listStyle: 'none',
   },
   Image: {
-    maxWidth: '100%'
+    width: '100%',
+    maxWidth: 800
   },
 }));
 

--- a/styles/plots.style.tsx
+++ b/styles/plots.style.tsx
@@ -4,6 +4,9 @@ export const useStyles = makeStyles(theme => ({
   listItem: {
     listStyle: 'none',
   },
+  Image: {
+    maxWidth: '100%'
+  },
 }));
 
 export default useStyles


### PR DESCRIPTION
Addition of help text for convergence plot and objective plot (@SQBL please review if the text is fitting). This is related to issue #9.

Furthermore the width of both plots have been set to 800 pixels to avoid cropping by the card. This is related to issue #70 (@j-or Please review if this is a suitable fix). 