### PR TITLE
Add minimum to handle static export.

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_EXPERIMENT_ENDPOINT=/api/experiment/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,43 @@ The included script "dockeryarn.sh" can be used as substitute for yarn if you ha
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+## Static export
+
+This allows for the project to be used as a client side application.
+
+```bash
+yarn export
+```
+
+The above will produce `/out` which can be served on any static host.
+
+### Caveats
+
+Be aware that the `/api/` routes will not and the functionality
+will have to be subsituted in some other fashion be it a serverless function or
+a seperate server instance.
+
+In order to substitute the stock `/api/` endpoint you need to define a `.env.local`
+file, before you run the `yarn export` command that overrides the `.env` file.
+
+```
+# .env.local
+NEXT_PUBLIC_EXPERIMENT_ENDPOINT=/some-other-api/experiment-alternative/
+```
+
+the final request might look something along the lines of:
+
+```
+https://some-other-api.com/random-region?id=1234
+```
+
+which would mean that for the last example the `.env.local` would look like this:
+
+```
+# .env.local
+NEXT_PUBLIC_EXPERIMENT_ENDPOINT=https://some-other-api.com/random-region
+```
+
 ## Update OpenAPI client
 
 When the process-optimizer-api changes, adjust the API version in the "openapi" script in package.json run the following command and commit the resulting changes.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The above will produce `/out` which can be served on any static host.
 
 ### Caveats
 
-Be aware that the `/api/` routes will not and the functionality
+Be aware that the `/api/` routes will not work and the functionality
 will have to be subsituted in some other fashion be it a serverless function or
 a seperate server instance.
 

--- a/context/experiment-context.tsx
+++ b/context/experiment-context.tsx
@@ -76,12 +76,22 @@ function useExperiment() {
     return context
 }
 
+function constructExperimentEndpoint(experiment: ExperimentType) {
+    return `${process.env.NEXT_PUBLIC_EXPERIMENT_ENDPOINT}${experiment.id}`
+}
+
 async function saveExperiment(experiment: ExperimentType) {
-    return fetch(`/api/experiment/${experiment.id}`, { method: 'PUT', body: JSON.stringify(experiment) })
+    return fetch(
+        constructExperimentEndpoint(experiment),
+        { method: 'PUT', body: JSON.stringify(experiment) }
+    )
 }
 
 async function runExperiment(dispatch: Dispatch, experiment: ExperimentType) {
-    const response: Response = await fetch(`/api/experiment/${experiment.id}`, { method: 'POST', body: JSON.stringify(experiment) })
+    const response: Response = await fetch(
+        constructExperimentEndpoint(experiment),
+        { method: 'POST', body: JSON.stringify(experiment) }
+    )
     const result: ExperimentResultType = await response.json()
     dispatch({ type: 'registerResult', payload: result })
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "export": "yarn build && next export",
     "test": "jest",
     "openapi": "openapi-generator-cli generate --skip-validate-spec -i https://raw.githubusercontent.com/BoostV/process-optimizer-api/v1.4.0/optimizerapi/openapi/specification.yml -g typescript-fetch -o ./openapi"
   },


### PR DESCRIPTION
Presently, the infrastructure we are dealing with cannot handle an active server handling our front-end.
Therefore, it would be beneficial if the project was able to be statically hosted.

The only thing stopping this from being independent of an active server running it, is as far as I can tell the API routes.

We try to make the paths to the functions that the FE calls less hard, and basically allow for whoever is consuming the FE to choose their experiment endpoint.

This isn't as nice as being able to use the build in API routes, but it does allow us to host it statically.

If we were to abstract the API routes a bit, we would also be able to make use of the logic in them in a decoupled instance.
Have them run in their own separate environment such as lambda or any other HTTP server for that matter.

Reference:
https://nextjs.org/docs/advanced-features/static-html-export
https://nextjs.org/docs/basic-features/environment-variables