### PR TITLE
Feature/add "Create or Overwrite experiment" dialog

### DIFF
--- a/components/create-or-overwrite-dialog/create-or-overwrite-dialog.tsx
+++ b/components/create-or-overwrite-dialog/create-or-overwrite-dialog.tsx
@@ -1,0 +1,48 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core'
+
+type CreateOrOverwriteDialogProps = {
+  handleCancel: () => void
+  handleOverwrite: () => void
+  handleCreate: () => void
+  open: boolean
+}
+
+export const CreateOrOverwriteDialog = (
+  props: CreateOrOverwriteDialogProps
+) => {
+  return (
+    <Dialog
+      open={props.open}
+      onClose={props.handleCancel}
+      aria-labelledby="create-or-overwrite-dialog-title"
+      aria-describedby="create-or-overwrite-dialog-description"
+    >
+      <DialogTitle id="create-or-overwrite-dialog-title">
+        Experiment with the same id already exists.
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="create-or-overwrite-dialog-description">
+          Do you want to overwrite the existing experiment or create a new one?
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.handleCancel} color="secondary">
+          Cancel
+        </Button>
+        <Button onClick={props.handleOverwrite} color="primary">
+          Overwrite
+        </Button>
+        <Button onClick={props.handleCreate} color="primary" autoFocus>
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
Whenever you try to upload an experiment that already exists we prompt the user with a dialog, asking them to pick if the experiment should be overwritten or create a new experiment with the same data.


