### PR TITLE
Prepend "/" to experiment paths

### DIFF
--- a/components/home/home.tsx
+++ b/components/home/home.tsx
@@ -19,7 +19,7 @@ import { NextRouter, useRouter } from 'next/router'
 import SystemUpdateAltIcon from '@material-ui/icons/SystemUpdateAlt'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import DeleteIcon from '@material-ui/icons/Delete'
-import { paths } from '../../paths'
+import { buildPath, paths } from '../../paths'
 import { ExperimentType } from '../../types/common'
 import { useGlobal } from '../../context/global-context'
 import { v4 as uuid } from 'uuid'
@@ -49,7 +49,7 @@ export default function Home() {
   const saveExperimentLocally = useCallback(
     (experiment: ExperimentType) => {
       localStorage.setItem(experiment.id, JSON.stringify({ experiment }))
-      router.push(`${paths.experiment}/${experiment.id}`)
+      router.push(buildPath(paths.experiment, experiment.id))
     },
     [router]
   )
@@ -104,12 +104,12 @@ export default function Home() {
 
   const createNewExperiment = () => {
     deleteExperiments()
-    router.push(`${paths.experiment}/${uuid()}`)
+    router.push(buildPath(paths.experiment, uuid()))
   }
 
   const openSavedExperiment = (key: string) => {
     deleteExperiments()
-    router.push(`${paths.experiment}/${key}`)
+    router.push(buildPath(paths.experiment, key))
   }
 
   const getExperimentName = (key: string) => {

--- a/paths.ts
+++ b/paths.ts
@@ -1,3 +1,16 @@
 export const paths = {
   experiment: 'experiment',
 }
+
+export function buildPath(...paths: string[]): string {
+  /*
+  We want the '/' at the beginning since this is the only way we can
+  get router.push to respect the relative "basePath" configuration.
+  If we did not have the prepended "/", a navigation from ex.
+  https://some-domain.com/nested/base/path to an experiment, and the basePath
+  set to "basePath: '/nested/base/path'" would result in
+  https://some-domain.com/nested/base/experiment/1234 and not
+  https://some-domain.com/nested/base/path/experiment/1234 as expected.
+  */
+  return '/' + paths.join('/')
+}


### PR DESCRIPTION
As stated in the implementation this is required if we are to respect the "basePath" configuration and have the ability to have the application located in a nested path.