### PR TITLE
Change Xi to descriptive text

### DIFF
--- a/src/components/result-data/next-experiments.tsx
+++ b/src/components/result-data/next-experiments.tsx
@@ -1,4 +1,4 @@
-import { Divider, Stack, TextField } from '@mui/material'
+import { Divider, Stack, TextField, Tooltip } from '@mui/material'
 import { ChangeEvent } from 'react'
 import { useExperiment } from '../../context/experiment-context'
 
@@ -42,14 +42,21 @@ export const NextExperiments = () => {
         label="Number of suggested experiments"
         onChange={handleSuggestionChange}
       />
-      <TextField
-        fullWidth
-        type="number"
-        value={experiment.optimizerConfig.xi}
-        name="Xi"
-        label="Xi"
-        onChange={handleXiChange}
-      />
+      <Tooltip
+        enterDelay={1000}
+        arrow={true}
+        placement="top-start"
+        title="Desired improvement in relation to the best result obtained thus far. Use the same scale as your scores and update this value as you gather more data. Large values result in suggestions far away from previously tried settings, small values result in suggestions close to the expected minimum of the model. As an example, if your best result is 100 and you wish to reach 25, this value should be set to 75"
+      >
+        <TextField
+          fullWidth
+          type="number"
+          value={experiment.optimizerConfig.xi}
+          name="Xi"
+          label="Desired further improvement"
+          onChange={handleXiChange}
+        />
+      </Tooltip>
     </Stack>
   )
 }


### PR DESCRIPTION
This PR will change the label "Xi" to a more descriptive text.
A tooltip containing a thorough help text is shown when hovering over the input field.
There should always be plenty of space above the input field and the tooltip should not get in the way.

Closes #187

## Example of the tooltip
<img width="338" alt="image" src="https://user-images.githubusercontent.com/558239/186028024-df330d81-0fec-44f2-9e22-50066e99ab0e.png">
<img width="871" alt="image" src="https://user-images.githubusercontent.com/558239/186028101-632d4ea9-03ed-4408-b409-3033c7fe6ac0.png">
