### PR TITLE
fix ports in the docker commands in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ npm run dev:app
 
 ```bash
 docker build -t process-optimizer-frontend .
-docker run --rm -it --name process-optimizer-frontend -p 80:80 --env API_URL=http://localhost:9090/v1.0 process-optimizer-frontend
+docker run --rm -it --name process-optimizer-frontend -p 8080:80 --env API_URL=http://localhost:9090/v1.0 process-optimizer-frontend
 ```
 
 ## Run pre-built docker image
 
 ```bash
-docker run -d -p80:80 --env API_URL=http://localhost:9090/v1.0 ghcr.io/boostv/process-optimizer-frontend:main
+docker run -d -p 8080:80 --env API_URL=http://localhost:9090/v1.0 ghcr.io/boostv/process-optimizer-frontend:main
 ```
 
 ## Update OpenAPI client

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ npm run dev:app
 
 ```bash
 docker build -t process-optimizer-frontend .
-docker run --rm -it --name process-optimizer-frontend -p 3000:3000 --env API_URL=http://localhost:9090/v1.0 process-optimizer-frontend
+docker run --rm -it --name process-optimizer-frontend -p 80:80 --env API_URL=http://localhost:9090/v1.0 process-optimizer-frontend
 ```
 
 ## Run pre-built docker image
 
 ```bash
-docker run -d -p3000:3000 --env API_URL=http://localhost:9090/v1.0 ghcr.io/boostv/process-optimizer-frontend:main
+docker run -d -p80:80 --env API_URL=http://localhost:9090/v1.0 ghcr.io/boostv/process-optimizer-frontend:main
 ```
 
 ## Update OpenAPI client


### PR DESCRIPTION
This PR changes the port mapping in the docker commands written in the README to reflect the fact that the frontend is being run with nginx which defaults to port 80.