### PR TITLE
feat: deficit-driven initialization suggestions

### DIFF
--- a/.changeset/quick-maps-shine.md
+++ b/.changeset/quick-maps-shine.md
@@ -1,0 +1,6 @@
+---
+'@boostv/process-optimizer-frontend-core': patch
+'@boostv/process-optimizer-frontend-ui': patch
+---
+
+Reset suggestion count to 1 after the model is first fit

--- a/.changeset/true-snakes-spend.md
+++ b/.changeset/true-snakes-spend.md
@@ -1,0 +1,6 @@
+---
+'@boostv/process-optimizer-frontend-core': minor
+'@boostv/process-optimizer-frontend-ui': minor
+---
+
+Introduce new deficit driven experimentation guide

--- a/packages/core/src/context/experiment/experiment-reducers.test.ts
+++ b/packages/core/src/context/experiment/experiment-reducers.test.ts
@@ -67,7 +67,7 @@ describe('experimentReducer pareto selection invalidation', () => {
     })
     const next = experimentReducer(stateWithSuggestion, {
       type: 'copySuggestedToDataPoints',
-      payload: [0],
+      payload: { indices: [0], removeFromSuggestions: false },
     })
     expect('selectedPoint' in next.extras).toBe(false)
   })

--- a/packages/core/src/context/experiment/experiment-reducers.ts
+++ b/packages/core/src/context/experiment/experiment-reducers.ts
@@ -532,13 +532,22 @@ export const experimentReducer = (
       // A stored pareto selection's coordinates go stale on any structural edit.
       delete draft.extras.selectedPoint
     }
-    // When the model is first fit (active data points reach initialPoints), reset
-    // the suggestion count to its default of 1. While initializing the count is
-    // forced to initialPoints; without this it would "stick" at that value once
-    // the model is built instead of dropping back to a single suggestion.
+  })
+}
+
+// Reset the suggestion count to its default of 1 once the model is first fit
+// (active data points reach initialPoints). MUST run after the validation reducer
+// (see rootReducer): the init→fit transition is normally driven by a row becoming
+// valid when its score is entered, and meta.valid is only set by validation — so
+// checking before validation (e.g. inside experimentReducer) misses the transition.
+export const resetSuggestionCountOnModelFit = (
+  previous: ExperimentType,
+  next: ExperimentType
+): ExperimentType =>
+  produce(next, draft => {
     const initialPoints = selectInitialPointsFromExperiment(next)
     const wasInitializing =
-      selectActiveDataPointsFromExperiment(state).length < initialPoints
+      selectActiveDataPointsFromExperiment(previous).length < initialPoints
     const nowFitted =
       selectActiveDataPointsFromExperiment(next).length >= initialPoints
     if (
@@ -549,7 +558,6 @@ export const experimentReducer = (
       delete draft.extras.experimentSuggestionCount
     }
   })
-}
 
 const updateNamesInConstraints = (
   state: ExperimentType,

--- a/packages/core/src/context/experiment/experiment-reducers.ts
+++ b/packages/core/src/context/experiment/experiment-reducers.ts
@@ -158,7 +158,7 @@ export type ExperimentAction =
     }
   | {
       type: 'copySuggestedToDataPoints'
-      payload: number[]
+      payload: { indices: number[]; removeFromSuggestions: boolean }
     }
   | {
       type: 'experiment/toggleMultiObjective'
@@ -208,10 +208,11 @@ const experimentReducerInner = produce(
         break
       }
       case 'copySuggestedToDataPoints': {
+        const { indices, removeFromSuggestions } = action.payload
         const nextValues = selectNextValues(state)
         const variables = selectActiveVariablesFromExperiment(state)
         const newEntries: DataEntry[] = nextValues
-          .filter((_, i) => action.payload.includes(i))
+          .filter((_, i) => indices.includes(i))
           .map((n, k) => ({
             meta: {
               enabled: true,
@@ -252,6 +253,29 @@ const experimentReducerInner = produce(
             newEntries
           )
         )
+        // Draw-down: transferred suggestions leave the list. Always while
+        // initializing (the transferred rows now occupy those initial slots);
+        // when fitted it is governed by the dispatcher's flag. The pushed rows
+        // are unscored (valid: false) so this does not change `isInitializing`.
+        const isInitializing =
+          selectActiveDataPointsFromExperiment(state).length <
+          selectInitialPointsFromExperiment(state)
+        if (isInitializing || removeFromSuggestions) {
+          // Filter the normalized `nextValues` (same array the transferred rows
+          // were selected from) so the kept/removed indices always align,
+          // regardless of how `results.next` was shaped on the wire.
+          state.results.next = nextValues.filter((_, i) => !indices.includes(i))
+        }
+        if (isInitializing) {
+          // Consuming initial suggestions removes them from the list, so the last
+          // evaluation's plan is no longer fully present. Mark the experiment as
+          // needing re-evaluation (the standard "never-calculated" sentinel →
+          // changedSinceLastEvaluation becomes true) so the guide regenerates the
+          // deficit even when the optimizer request later round-trips to a
+          // previously-evaluated state — e.g. disabling a transferred, unscored
+          // point leaves the request identical to before the transfer.
+          state.lastEvaluationHash = 'never-calculated'
+        }
         break
       }
       case 'addValueVariable':

--- a/packages/core/src/context/experiment/experiment-selectors.test.ts
+++ b/packages/core/src/context/experiment/experiment-selectors.test.ts
@@ -6,6 +6,8 @@ import {
   selectActiveVariablesFromExperiment,
   selectCalculatedSuggestionCount,
   selectId,
+  selectInitializationDeficit,
+  selectInitializationDeficitFromExperiment,
   selectIsConstraintActive,
   selectIsInitializing,
   selectIsMultiObjective,
@@ -122,10 +124,10 @@ describe('Experiment selectors', () => {
       },
     ]
     it.each([
-      //data points < initial points, constraint active -> initial points
-      [1, 2, constraints, 2],
-      //data points < initial points, constraint NOT active -> initial points
-      [1, 2, [], 2],
+      //data points < initial points -> deficit (initialPoints - dataPoints)
+      [1, 2, constraints, 1],
+      //data points < initial points, constraint NOT active -> deficit
+      [1, 2, [], 1],
       //data points = initial points, constraint active -> 1
       [1, 1, constraints, 1],
       //data points = initial points, constraint NOT active -> suggestionCount
@@ -134,6 +136,8 @@ describe('Experiment selectors', () => {
       [2, 1, constraints, 1],
       //data points > initial points, constraint NOT active -> suggestionCount
       [2, 1, [], suggestionCount],
+      //data points 0, initial points 3 -> deficit 3
+      [0, 3, [], 3],
     ])(
       'should return correct value',
       (dataPoints, initialPoints, constraints, result) => {
@@ -156,6 +160,72 @@ describe('Experiment selectors', () => {
         expect(editable).toBe(result)
       }
     )
+  })
+
+  describe('selectInitializationDeficitFromExperiment', () => {
+    const withConfigAndPoints = (
+      initialPoints: number,
+      points: { enabled: boolean; valid: boolean }[]
+    ): ExperimentType => ({
+      ...initialState.experiment,
+      optimizerConfig: {
+        ...initialState.experiment.optimizerConfig,
+        initialPoints,
+      },
+      dataPoints: points.map((p, i) => ({
+        meta: { id: i + 1, enabled: p.enabled, valid: p.valid },
+        data: [{ type: 'numeric', name: 'Water', value: 100 }],
+      })),
+    })
+
+    it('returns initialPoints when there are no rows', () => {
+      expect(
+        selectInitializationDeficitFromExperiment(withConfigAndPoints(3, []))
+      ).toBe(3)
+    })
+
+    it('counts an enabled but unscored (transferred) row as occupying a slot', () => {
+      const exp = withConfigAndPoints(3, [
+        { enabled: true, valid: false },
+        { enabled: true, valid: false },
+        { enabled: true, valid: false },
+      ])
+      expect(selectInitializationDeficitFromExperiment(exp)).toBe(0)
+    })
+
+    it('treats a disabled row as a missing slot', () => {
+      const exp = withConfigAndPoints(3, [
+        { enabled: true, valid: true },
+        { enabled: true, valid: true },
+        { enabled: false, valid: true },
+      ])
+      expect(selectInitializationDeficitFromExperiment(exp)).toBe(1)
+    })
+
+    it('never goes below zero', () => {
+      const exp = withConfigAndPoints(2, [
+        { enabled: true, valid: true },
+        { enabled: true, valid: true },
+        { enabled: true, valid: true },
+      ])
+      expect(selectInitializationDeficitFromExperiment(exp)).toBe(0)
+    })
+
+    it('selectInitializationDeficit reads from state', () => {
+      expect(
+        selectInitializationDeficit({
+          ...initialState,
+          experiment: {
+            ...initialState.experiment,
+            optimizerConfig: {
+              ...initialState.experiment.optimizerConfig,
+              initialPoints: 3,
+            },
+            dataPoints: [],
+          },
+        })
+      ).toBe(3)
+    })
   })
 
   describe('selectIsConstraintActive', () => {

--- a/packages/core/src/context/experiment/experiment-selectors.ts
+++ b/packages/core/src/context/experiment/experiment-selectors.ts
@@ -4,6 +4,10 @@ import { State } from './store'
 export const selectExperiment = (state: State) => state.experiment
 export const selectId = (state: State) => selectExperiment(state).id
 
+// Initializing = fewer SCORED (valid + enabled) points than initialPoints. Note
+// this counts valid+enabled rows, whereas selectInitializationDeficit* counts
+// merely enabled rows (an entered-but-unscored row still holds its slot) — the
+// two denominators differ on purpose.
 export const selectIsInitializing = (state: State) =>
   selectExperiment(state).optimizerConfig.initialPoints === 0 ||
   selectActiveDataPoints(state).length <
@@ -108,6 +112,22 @@ export const selectInitialPoints = (state: State) =>
 export const selectInitialPointsFromExperiment = (experiment: ExperimentType) =>
   experiment.optimizerConfig.initialPoints
 
+// During initialization, how many more experiments are needed to reach
+// initialPoints. A row "occupies a slot" if it is enabled (scored or not), so a
+// disabled row counts as missing — disabling re-opens a slot just like deleting.
+export const selectInitializationDeficitFromExperiment = (
+  experiment: ExperimentType
+) => {
+  const enabledRows = experiment.dataPoints.filter(d => d.meta.enabled).length
+  return Math.max(
+    0,
+    selectInitialPointsFromExperiment(experiment) - enabledRows
+  )
+}
+
+export const selectInitializationDeficit = (state: State) =>
+  selectInitializationDeficitFromExperiment(selectExperiment(state))
+
 export const selectIsSuggestionCountEditable = (state: State) => {
   const dataPoints = selectActiveDataPoints(state)
   const initialPoints = selectInitialPoints(state)
@@ -134,7 +154,7 @@ export const selectCalculatedSuggestionCountFromExperiment = (
   const initialPoints = selectInitialPointsFromExperiment(experiment)
 
   if (dataPoints < initialPoints) {
-    return initialPoints
+    return selectInitializationDeficitFromExperiment(experiment)
   } else if (selectIsConstraintActive(experiment)) {
     return 1
   }

--- a/packages/core/src/context/experiment/reducers.test.ts
+++ b/packages/core/src/context/experiment/reducers.test.ts
@@ -15,6 +15,7 @@ import {
   emptyExperiment,
   State,
 } from '@core/context/experiment'
+import { selectNextValues } from './experiment-selectors'
 import { versionInfo } from '@core/common'
 import _ from 'lodash'
 import { produce } from 'immer'
@@ -1001,7 +1002,7 @@ describe('experiment reducer', () => {
     it('should copy one row from suggested to data points', () => {
       const action: ExperimentAction = {
         type: 'copySuggestedToDataPoints',
-        payload: [0],
+        payload: { indices: [0], removeFromSuggestions: false },
       }
       const dp = rootReducer(initState, action).experiment.dataPoints
       expect(dp.length).toBe(2)
@@ -1025,7 +1026,7 @@ describe('experiment reducer', () => {
     it('should copy multiple rows from suggested to data points', () => {
       const action: ExperimentAction = {
         type: 'copySuggestedToDataPoints',
-        payload: [0, 1],
+        payload: { indices: [0, 1], removeFromSuggestions: false },
       }
       const dp = rootReducer(initState, action).experiment.dataPoints
       expect(dp.length).toBe(3)
@@ -1050,7 +1051,7 @@ describe('experiment reducer', () => {
     it('should only copy enabled variables to data points', () => {
       const action: ExperimentAction = {
         type: 'copySuggestedToDataPoints',
-        payload: [0],
+        payload: { indices: [0], removeFromSuggestions: false },
       }
       const state: State = {
         ...initState,
@@ -1091,6 +1092,106 @@ describe('experiment reducer', () => {
         },
       ])
     })
+
+    it('removes transferred suggestions from the list while initializing', () => {
+      const action: ExperimentAction = {
+        type: 'copySuggestedToDataPoints',
+        payload: { indices: [0], removeFromSuggestions: false },
+      }
+      const before = selectNextValues(initState.experiment).length
+      const next = rootReducer(initState, action).experiment.results.next
+      expect(next.length).toBe(before - 1)
+      expect(next[0]).toEqual([150, 'Chocolate'])
+    })
+
+    it('keeps suggestions when fitted and removeFromSuggestions is false', () => {
+      const fitted: State = {
+        ...initState,
+        experiment: {
+          ...initState.experiment,
+          optimizerConfig: {
+            ...initState.experiment.optimizerConfig,
+            initialPoints: 1,
+          },
+          dataPoints: [
+            {
+              meta: { id: 1, enabled: true, valid: true },
+              data: [
+                { type: 'numeric', name: 'Water', value: 100 },
+                { type: 'categorical', name: 'Icing', value: 'Vanilla' },
+                { type: 'score', name: scoreNames[0], value: 10 },
+              ],
+            },
+          ],
+          results: {
+            ...initState.experiment.results,
+            next: [
+              [100, 'Vanilla'],
+              [150, 'Chocolate'],
+            ],
+          },
+        },
+      }
+      const keep: ExperimentAction = {
+        type: 'copySuggestedToDataPoints',
+        payload: { indices: [0], removeFromSuggestions: false },
+      }
+      expect(rootReducer(fitted, keep).experiment.results.next.length).toBe(2)
+
+      const drop: ExperimentAction = {
+        type: 'copySuggestedToDataPoints',
+        payload: { indices: [0], removeFromSuggestions: true },
+      }
+      expect(rootReducer(fitted, drop).experiment.results.next.length).toBe(1)
+    })
+
+    it('stays "changed" after transferring then disabling an initial suggestion (round-trip)', () => {
+      // Build a base state with initialPoints 2 and xi pre-set to 0.1 (what
+      // calculateXi returns for the single scored point with score 10) so that
+      // updateDataPoints does not change xi and accidentally cause a hash mismatch
+      // unrelated to the bug under test.
+      const base: State = {
+        ...initState,
+        experiment: {
+          ...initState.experiment,
+          optimizerConfig: {
+            ...initState.experiment.optimizerConfig,
+            initialPoints: 2,
+            xi: 0.1,
+          },
+        },
+      }
+      // Sync lastEvaluationHash to the current request so changed is false
+      // (simulates the evaluation that produced the suggestions).
+      const synced = rootReducer(base, {
+        type: 'registerResult',
+        payload: {
+          experimentVersion: base.experiment.info.version,
+          result: base.experiment.results,
+        },
+      })
+      expect(synced.experiment.changedSinceLastEvaluation).toBe(false)
+
+      // Transfer the first suggestion (draw-down removes it from the list).
+      const transferred = rootReducer(synced, {
+        type: 'copySuggestedToDataPoints',
+        payload: { indices: [0], removeFromSuggestions: true },
+      })
+
+      // Disable the newly added, still-unscored row (valid === false).
+      const disabledDataPoints = transferred.experiment.dataPoints.map(d =>
+        d.meta.valid ? d : { ...d, meta: { ...d.meta, enabled: false } }
+      )
+      const afterDisable = rootReducer(transferred, {
+        type: 'updateDataPoints',
+        payload: disabledDataPoints,
+      })
+
+      // The request now round-trips to the pre-transfer state, but the list was
+      // consumed — the experiment must still be marked changed so the guide
+      // re-evaluates and regenerates the deficit.
+      expect(afterDisable.experiment.changedSinceLastEvaluation).toBe(true)
+    })
   })
 
   it('should add scores to new data point for multi-objective - two scores enabled', () => {
@@ -1116,7 +1217,7 @@ describe('experiment reducer', () => {
     }
     const action: ExperimentAction = {
       type: 'copySuggestedToDataPoints',
-      payload: [0],
+      payload: { indices: [0], removeFromSuggestions: false },
     }
     const dp = rootReducer(testState, action).experiment.dataPoints
     expect(dp[dp.length - 1]?.data).toEqual([
@@ -1155,7 +1256,7 @@ describe('experiment reducer', () => {
     }
     const action: ExperimentAction = {
       type: 'copySuggestedToDataPoints',
-      payload: [0],
+      payload: { indices: [0], removeFromSuggestions: false },
     }
     const dp = rootReducer(testState, action).experiment.dataPoints
     expect(dp[dp.length - 1]?.data).toEqual([

--- a/packages/core/src/context/experiment/reducers.test.ts
+++ b/packages/core/src/context/experiment/reducers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ExperimentAction, experimentReducer } from './experiment-reducers'
+import { ExperimentAction } from './experiment-reducers'
 import { rootReducer } from './reducers'
 import {
   currentVersion,
@@ -1393,28 +1393,45 @@ describe('resetting suggestion count when the model is first fit (#1)', () => {
 
   it('drops experimentSuggestionCount to its default when active points reach initialPoints', () => {
     const before = withPoints(2, { experimentSuggestionCount: 5 })
-    const after = experimentReducer(before, {
-      type: 'updateDataPoints',
-      payload: createDataPoints(3),
-    })
+    const after = rootReducer(
+      { experiment: before },
+      { type: 'updateDataPoints', payload: createDataPoints(3) }
+    ).experiment
     expect('experimentSuggestionCount' in after.extras).toBe(false)
   })
 
   it('keeps the count while still initializing (below initialPoints)', () => {
     const before = withPoints(1, { experimentSuggestionCount: 5 })
-    const after = experimentReducer(before, {
-      type: 'updateDataPoints',
-      payload: createDataPoints(2),
-    })
+    const after = rootReducer(
+      { experiment: before },
+      { type: 'updateDataPoints', payload: createDataPoints(2) }
+    ).experiment
     expect(after.extras.experimentSuggestionCount).toBe(5)
   })
 
   it('keeps the count once already fitted (does not reset on every added point)', () => {
     const before = withPoints(3, { experimentSuggestionCount: 4 })
-    const after = experimentReducer(before, {
-      type: 'updateDataPoints',
-      payload: createDataPoints(4),
-    })
+    const after = rootReducer(
+      { experiment: before },
+      { type: 'updateDataPoints', payload: createDataPoints(4) }
+    ).experiment
     expect(after.extras.experimentSuggestionCount).toBe(4)
+  })
+
+  it('resets once the last initial point becomes valid via the validation reducer (score entry)', () => {
+    const before = withPoints(2, { experimentSuggestionCount: 5 })
+    // The data-points UI dispatches the new/edited row before validity is
+    // recomputed, so the payload's last row is not yet marked valid.
+    const payload = produce(createDataPoints(3), draft => {
+      const last = draft[draft.length - 1]
+      if (last) last.meta.valid = false
+    })
+    const after = rootReducer(
+      { experiment: before },
+      { type: 'updateDataPoints', payload }
+    ).experiment
+    // validation flips it valid -> active reaches initialPoints -> reset fires
+    expect(after.dataPoints[after.dataPoints.length - 1]?.meta.valid).toBe(true)
+    expect('experimentSuggestionCount' in after.extras).toBe(false)
   })
 })

--- a/packages/core/src/context/experiment/reducers.ts
+++ b/packages/core/src/context/experiment/reducers.ts
@@ -1,6 +1,10 @@
 import { assertUnreachable } from '@core/common/util'
 import { State } from './store'
-import { ExperimentAction, experimentReducer } from './experiment-reducers'
+import {
+  ExperimentAction,
+  experimentReducer,
+  resetSuggestionCountOnModelFit,
+} from './experiment-reducers'
 import { validateExperiment, ValidationViolations } from './validation'
 import { validationReducer } from './validation-reducer'
 import { calculateChangeReducer } from './calculate-change-reducer'
@@ -36,10 +40,11 @@ export const rootReducer = (state: State, action: Action) => {
       const experiment = experimentReducer(state.experiment, action)
       const validationViolations: ValidationViolations =
         validateExperiment(experiment)
+      const validated = validationReducer(experiment, validationViolations)
       return {
         ...state,
         experiment: calculateChangeReducer(
-          validationReducer(experiment, validationViolations)
+          resetSuggestionCountOnModelFit(state.experiment, validated)
         ),
       }
     }

--- a/packages/core/src/context/experiment/test-utils.ts
+++ b/packages/core/src/context/experiment/test-utils.ts
@@ -135,7 +135,7 @@ export const dummyPayloads: Payloads = {
   updateSuggestionCount: {
     suggestionCount: '',
   },
-  copySuggestedToDataPoints: [],
+  copySuggestedToDataPoints: { indices: [], removeFromSuggestions: false },
   'experiment/toggleMultiObjective': undefined,
   'experiment/setConstraintSum': 0,
   'experiment/addVariableToConstraintSum': '',

--- a/packages/ui/src/containers/result-data/experimentation-guide.tsx
+++ b/packages/ui/src/containers/result-data/experimentation-guide.tsx
@@ -5,6 +5,7 @@ import {
   selectIsInitializing,
   selectActiveVariableNames,
   selectDataPoints,
+  selectInitializationDeficit,
 } from '@boostv/process-optimizer-frontend-core'
 import {
   Tooltip,
@@ -35,6 +36,9 @@ interface ResultDataProps {
   warning?: string
   padding?: number
   allowIndividualSuggestionCopy?: boolean
+  // When fitted, transferring a suggestion removes it from the list (draw-down).
+  // Defaults to on; set false to keep transferred suggestions visible.
+  drawDownSuggestionsWhenFitted?: boolean
   maxSuggestionCount?: number
   toggleUISize?: () => void
   onMouseEnterExpand?: () => void
@@ -51,6 +55,7 @@ export const ExperimentationGuide = (props: ResultDataProps) => {
     padding,
     loadingMode,
     allowIndividualSuggestionCopy = true,
+    drawDownSuggestionsWhenFitted = true,
     maxSuggestionCount,
     toggleUISize,
     onMouseEnterExpand,
@@ -66,6 +71,19 @@ export const ExperimentationGuide = (props: ResultDataProps) => {
   const variableHeaders = useSelector(selectActiveVariableNames)
   const isInitializing = useSelector(selectIsInitializing)
   const dataPoints = useSelector(selectDataPoints)
+  const deficit = useSelector(selectInitializationDeficit)
+  // While initializing, once every initial slot is filled (deficit 0) no further
+  // suggestions are needed — ignore any stale/extra suggestions still in the list
+  // so the guide shows the "all added, go run them" guidance (where the
+  // suggestions would otherwise be) instead of inviting more transfers.
+  const allInitialPointsAdded = isInitializing && deficit === 0
+  const displayedSuggestions = allInitialPointsAdded ? [] : nextValues
+
+  const emptyListMessage = allInitialPointsAdded
+    ? 'All initial experiments have been added to the data points list. Run them and enter their results to finish initializing the model — or delete or disable a row to get a replacement suggestion.'
+    : isInitializing
+      ? 'Calculating initial suggestions…'
+      : 'Please run optimizer to calculate suggestions'
 
   const defaultLoadingView = (
     <Stack direction="column" spacing={2} m={2}>
@@ -144,18 +162,20 @@ export const ExperimentationGuide = (props: ResultDataProps) => {
       }
     >
       <Box p={2}>
-        {!nextValues ||
-          (nextValues.length === 0 && (
-            <Box p={2}>Please run optimizer to calculate suggestions</Box>
-          ))}
+        {displayedSuggestions.length === 0 && (
+          <Box p={2}>{emptyListMessage}</Box>
+        )}
         <Suggestions
-          values={nextValues}
+          values={displayedSuggestions}
           headers={variableHeaders}
           allowIndividualSuggestionCopy={allowIndividualSuggestionCopy}
           onCopyToDataPoints={index =>
             dispatchExperiment({
               type: 'copySuggestedToDataPoints',
-              payload: [index],
+              payload: {
+                indices: [index],
+                removeFromSuggestions: drawDownSuggestionsWhenFitted,
+              },
             })
           }
         />
@@ -177,16 +197,21 @@ export const ExperimentationGuide = (props: ResultDataProps) => {
             />
           </Box>
         )}
-        {nextValues.length > 0 &&
-          nextValues[0] !== undefined &&
-          nextValues[0].length > 0 && (
+        {displayedSuggestions.length > 0 &&
+          displayedSuggestions[0] !== undefined &&
+          displayedSuggestions[0].length > 0 && (
             <Box>
               <CopySuggested
                 isInitialInteraction={dataPoints.length === 0}
                 onClick={() =>
                   dispatchExperiment({
                     type: 'copySuggestedToDataPoints',
-                    payload: [...Array(nextValues.length)].map((_, i) => i),
+                    payload: {
+                      indices: [...Array(displayedSuggestions.length)].map(
+                        (_, i) => i
+                      ),
+                      removeFromSuggestions: drawDownSuggestionsWhenFitted,
+                    },
                   })
                 }
               />


### PR DESCRIPTION
During the optimizer's initialization phase the suggestion list represents the initial experiments still to be planned. The requested suggestion count is the deficit to initialPoints (initialPoints minus enabled data-point rows); transferring suggestions draws them out of the list (configurable when fitted via drawDownSuggestionsWhenFitted, default on); and consuming initial suggestions marks the experiment for re-evaluation so the deficit is always regenerated fresh, even when a later edit round-trips the optimizer request to a previously-evaluated state. Adds context-aware empty-suggestion-list copy.